### PR TITLE
Add vertex color import option

### DIFF
--- a/blender-for-unrealengine - 2.8/__init__.py
+++ b/blender-for-unrealengine - 2.8/__init__.py
@@ -253,6 +253,7 @@ class BFU_PT_BlenderForUnreal(bpy.types.Panel):
 							'obj.AutoGenerateCollision',
 							'obj.MaterialSearchLocation',
 							'obj.CollisionTraceFlag',
+							'obj.VertexColorImportOption',
 							'obj.exportActionEnum',
 							'obj.PrefixNameToExport',
 							'obj.AnimStartEndTimeEnum',
@@ -543,6 +544,17 @@ class BFU_PT_ObjectImportProperties(bpy.types.Panel):
 			]
 		)
 
+	bpy.types.Object.VertexColorImportOption = EnumProperty(
+		name = "Vertex Color Import Option",
+		description = "Specify how vertex colors should be imported",
+		#Vania python -> https://docs.unrealengine.com/en-US/PythonAPI/class/VertexColorImportOption.html
+		#20tab python -> https://docs.unrealengine.com/en-US/API/Editor/UnrealEd/Factories/EVertexColorImportOption__Type/index.html
+		items = [
+			("VCIO_Ignore", "Ignore", "Ignore vertex colors from the FBX file, and keep the existing mesh vertex colors.", 1),
+			("VCIO_Replace", "Replace", "Import the static mesh using the vertex colors from the FBX file.", 2)
+			]
+		)
+
 
 	def draw(self, context):
 
@@ -583,6 +595,9 @@ class BFU_PT_ObjectImportProperties(bpy.types.Panel):
 						
 						StaticMeshCollisionTraceFlag = layout.row()
 						StaticMeshCollisionTraceFlag.prop(obj, 'CollisionTraceFlag')
+
+						StaticMeshVertexColorImportOption = layout.row()
+						StaticMeshVertexColorImportOption.prop(obj, 'VertexColorImportOption')
 
 						StaticMeshLightMapRes = layout.row()
 						StaticMeshLightMapRes.prop(obj, 'UseStaticMeshLightMapRes', text="")

--- a/blender-for-unrealengine - 2.8/bfu_WriteImportAssetScript.py
+++ b/blender-for-unrealengine - 2.8/bfu_WriteImportAssetScript.py
@@ -375,6 +375,10 @@ def WriteOneAssetTaskDef(asset, use20tab = False):
 			if obj.CollisionTraceFlag == "CTF_UseComplexAsSimple": python_CollisionTraceFlag = "CTF_USE_COMPLEX_AS_SIMPLE"
 			ImportScript += "\t" + "asset.get_editor_property('body_setup').set_editor_property('collision_trace_flag', unreal.CollisionTraceFlag." + python_CollisionTraceFlag + ") " + "\n"
 
+			if obj.VertexColorImportOption == "VCIO_Ignore" : python_VertexColorImportOption = "IGNORE"
+			if obj.VertexColorImportOption == "VCIO_Replace" : python_VertexColorImportOption = "REPLACE"
+			ImportScript += "\t" + "asset.get_editor_property('asset_import_data').set_editor_property('vertex_color_import_option', unreal.VertexColorImportOption." + python_VertexColorImportOption + ") " + "\n"
+
 
 
 	if asset.assetType == "SkeletalMesh":


### PR DESCRIPTION
I've implemented support for the vertex color import option for when a model is re-imported through the Unreal Editor.

![image](https://user-images.githubusercontent.com/2432608/78123045-e1ce1e00-740d-11ea-8a9f-677a421e08bf.png)

In the current version of your add-on this option was always set to the default "ignore" so later changes to vertex colors inside Blender could not be easily transferred to Unreal.

Please note that I did not implement the path for the **20tab plugin** because I don't use it. However, I have added the link to the matching class.
