### PR TITLE
Feature: 

### DIFF
--- a/blender-for-unrealengine/bfu_ui.py
+++ b/blender-for-unrealengine/bfu_ui.py
@@ -208,8 +208,7 @@ class BFU_PT_BlenderForUnrealObject(bpy.types.Panel):
     bpy.types.Object.bfu_use_custom_export_name = BoolProperty(
         name="Export with custom name.",
         description=(
-            "Only write deforming bones" +
-            " (and non-deforming ones when they have deforming children)"
+            "Specify a custom name for the exported file"
             ),
         override={'LIBRARY_OVERRIDABLE'},
         default=False
@@ -2293,9 +2292,15 @@ class BFU_PT_Export(bpy.types.Panel):
         maxlen=64,
         default="ImportSequencerScript.py")
 
+    bpy.types.Scene.unreal_import_module = bpy.props.StringProperty(
+        name="Unreal import module",
+        description="Which module (plugin name) to import to. Default is 'Game', meaning it will be put into your project's /Content/ folder. If you wish to import to a plugin (for example a plugin called 'myPlugin'), just write its name here",
+        maxlen=512,
+        default='Game')
+
     bpy.types.Scene.unreal_import_location = bpy.props.StringProperty(
         name="Unreal import location",
-        description="Unreal assets import location in /Game/",
+        description="Unreal assets import location inside the module",
         maxlen=512,
         default='ImportedFbx')
 
@@ -2338,6 +2343,7 @@ class BFU_PT_Export(bpy.types.Panel):
                             'scene.file_import_asset_script_name',
                             'scene.file_import_sequencer_script_name',
                             # Import location:
+                            'scene.unreal_import_module',
                             'scene.unreal_import_location',
                         ]
 
@@ -2795,6 +2801,11 @@ class BFU_PT_Export(bpy.types.Panel):
             propsSub.prop(scene, 'anim_subfolder_name', icon='FILE_FOLDER')
 
             if addon_prefs.useGeneratedScripts:
+                unreal_import_module = propsSub.column()
+                unreal_import_module.prop(
+                    scene,
+                    'unreal_import_module',
+                    icon='FILE_FOLDER')
                 unreal_import_location = propsSub.column()
                 unreal_import_location.prop(
                     scene,

--- a/blender-for-unrealengine/bfu_write_import_asset_script.py
+++ b/blender-for-unrealengine/bfu_write_import_asset_script.py
@@ -57,7 +57,7 @@ def WriteImportAssetScript():
         '3/3': ti('write_text_additional_track_end'),
     }
 
-    data['unreal_import_location'] = '/Game/' + scene.unreal_import_location
+    data['unreal_import_location'] = '/' + scene.unreal_import_module + '/' + scene.unreal_import_location
 
     # Import assets
     data['assets'] = []
@@ -81,7 +81,7 @@ def WriteImportAssetScript():
         else:
             relative_import_path = asset.folder_name
 
-        full_import_path = "/Game/" + os.path.join(scene.unreal_import_location, relative_import_path)
+        full_import_path = "/" + scene.unreal_import_module + "/" + os.path.join(scene.unreal_import_location, relative_import_path)
         full_import_path = full_import_path.replace('\\', '/').rstrip('/')
         asset_data["full_import_path"] = full_import_path
 
@@ -107,7 +107,7 @@ def WriteImportAssetScript():
                 SkeletonName = customName+"."+customName
                 SkeletonLoc = os.path.join(asset.folder_name, SkeletonName)
 
-                animation_skeleton_path = os.path.join("/Game/", scene.unreal_import_location, SkeletonLoc)
+                animation_skeleton_path = os.path.join("/" + scene.unreal_import_module + "/", scene.unreal_import_location, SkeletonLoc)
                 animation_skeleton_path = animation_skeleton_path.replace('\\', '/')
                 asset_data["animation_skeleton_path"] = animation_skeleton_path
 
@@ -116,14 +116,14 @@ def WriteImportAssetScript():
                 SkeletonName = customName+"."+customName
                 SkeletonLoc = os.path.join(asset.folder_name, SkeletonName)
 
-                animation_skeleton_path = os.path.join("/Game/", scene.unreal_import_location, SkeletonLoc)
+                animation_skeleton_path = os.path.join("/" + scene.unreal_import_module + "/", scene.unreal_import_location, SkeletonLoc)
                 animation_skeleton_path = animation_skeleton_path.replace('\\', '/')
                 asset_data["animation_skeleton_path"] = animation_skeleton_path
 
             elif(asset.object.bfu_skeleton_search_mode) == "custom_path_name":
                 customName = ValidUnrealAssetsName(asset.object.bfu_target_skeleton_custom_name)
                 SkeletonName = customName+"."+customName
-                SkeletonLoc = os.path.join("/Game/", asset.object.bfu_target_skeleton_custom_path, SkeletonName)
+                SkeletonLoc = os.path.join("/" + scene.unreal_import_module + "/", asset.object.bfu_target_skeleton_custom_path, SkeletonName)
                 asset_data["animation_skeleton_path"] = SkeletonLoc.replace('\\', '/')
 
             elif(asset.object.bfu_skeleton_search_mode) == "custom_reference":

--- a/blender-for-unrealengine/bfu_write_import_asset_script.py
+++ b/blender-for-unrealengine/bfu_write_import_asset_script.py
@@ -101,7 +101,7 @@ def WriteImportAssetScript():
         else:
             asset_data["additional_tracks_path"] = None
 
-        if GetIsAnimation(asset.asset_type):
+        if GetIsAnimation(asset.asset_type) or asset.asset_type == "SkeletalMesh":
             if(asset.object.bfu_skeleton_search_mode) == "auto":
                 customName = scene.skeletal_mesh_prefix_export_name+ValidUnrealAssetsName(asset.skeleton_name)+"_Skeleton"
                 SkeletonName = customName+"."+customName

--- a/blender-for-unrealengine/bfu_write_import_sequencer_script.py
+++ b/blender-for-unrealengine/bfu_write_import_sequencer_script.py
@@ -61,7 +61,7 @@ def WriteImportSequencerTracks():
     data['render_resolution_x'] = bpy.context.scene.render.resolution_x
     data['render_resolution_y'] = bpy.context.scene.render.resolution_y
     data['secureCrop'] = 0.0001  # add end crop for avoid section overlay
-    data['unreal_import_location'] = "/Game/" + scene.unreal_import_location
+    data['unreal_import_location'] = "/" + scene.unreal_import_module + "/" + scene.unreal_import_location
 
     # Import camera
     data['cameras'] = []

--- a/blender-for-unrealengine/import/asset_import_script.py
+++ b/blender-for-unrealengine/import/asset_import_script.py
@@ -105,7 +105,7 @@ def ImportAllAssets():
             # New import task
             # Property
 
-            if asset_data["type"] == "Animation":
+            if asset_data["type"] == "Animation" or asset_data["type"] == "SkeletalMesh":
                 find_asset = unreal.find_asset(asset_data["animation_skeleton_path"])
                 if isinstance(find_asset, unreal.Skeleton):
                     OriginSkeleton = find_asset
@@ -113,6 +113,10 @@ def ImportAllAssets():
                     OriginSkeleton = find_asset.skeleton
                 else:
                     OriginSkeleton = None
+                if OriginSkeleton:
+                    print("Setting skeleton asset: " + OriginSkeleton.get_full_name())
+                else:
+                    print("Could not find skeleton at the path: " + asset_data["animation_skeleton_path"])
 
             # docs.unrealengine.com/4.26/en-US/PythonAPI/class/AssetImportTask.html
             task = unreal.AssetImportTask()
@@ -211,12 +215,16 @@ def ImportAllAssets():
                 task.get_editor_property('options').set_editor_property('import_type', unreal.AlembicImportType.SKELETAL)
 
             else:
-                if asset_data["type"] == "Animation":
+                if asset_data["type"] == "Animation" or asset_data["type"] == "SkeletalMesh":
                     if OriginSkeleton:
                         task.get_editor_property('options').set_editor_property('Skeleton', OriginSkeleton)
                     else:
-                        ImportFailList.append('Skeleton ' + asset_data["animation_skeleton_path"] + ' Not found for ' + asset_data["name"] + ' asset.')
-                        return
+                        if asset_data["type"] == "Animation":
+                            ImportFailList.append('Skeleton ' + asset_data["animation_skeleton_path"] + ' Not found for ' + asset_data["name"] + ' asset.')
+                            return
+                        else:
+                            print("Skeleton is not set, a new skeleton asset will be created...")
+
 
                 if asset_data["type"] == "StaticMesh":
                     task.get_editor_property('options').set_editor_property('original_import_type', unreal.FBXImportType.FBXIT_STATIC_MESH)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7072585/194761481-6bb73256-a3b5-4e2c-8ca4-bbed37313464.png)

Adding two new features that I dearly needed:
+ Specifying skeleton asset now works with Skeletal Meshes, not only Animations
+ Can now specify which module (plugin) to import assets to. Defaults to /Game/ content folder like it used to.

(Might need some more testing with all other asset types, to make sure)