### PR TITLE
Add select/deselect all buttons for action export specific list

### DIFF
--- a/blender-for-unrealengine/bfu_anim_action/bfu_anim_action_props.py
+++ b/blender-for-unrealengine/bfu_anim_action/bfu_anim_action_props.py
@@ -155,7 +155,7 @@ class BFU_OT_SelectAllObjActionListButton(bpy.types.Operator):
         return {'FINISHED'}
 
 class BFU_OT_DeselectAllObjActionListButton(bpy.types.Operator):
-    bl_label = "Deselect"
+    bl_label = "Deselect All"
     bl_idname = "object.deselectallobjactionlist"
     bl_description = "Deselect all action list"
 

--- a/blender-for-unrealengine/bfu_anim_action/bfu_anim_action_props.py
+++ b/blender-for-unrealengine/bfu_anim_action/bfu_anim_action_props.py
@@ -143,6 +143,28 @@ class BFU_OT_UpdateObjActionListButton(bpy.types.Operator):
         UpdateExportActionList(bpy.context.object)
         return {'FINISHED'}
 
+class BFU_OT_SelectAllObjActionListButton(bpy.types.Operator):
+    bl_label = "Select All"
+    bl_idname = "object.selectallobjactionlist"
+    bl_description = "Select all action list"
+
+    def execute(self, context):
+        if bpy.context.object.bfu_action_asset_list:
+            for item in bpy.context.object.bfu_action_asset_list:
+                item.use = True
+        return {'FINISHED'}
+
+class BFU_OT_DeselectAllObjActionListButton(bpy.types.Operator):
+    bl_label = "Deselect"
+    bl_idname = "object.deselectallobjactionlist"
+    bl_description = "Deselect all action list"
+
+    def execute(self, context):
+        if bpy.context.object.bfu_action_asset_list:
+            for item in bpy.context.object.bfu_action_asset_list:
+                item.use = False
+        return {'FINISHED'}
+
 class BFU_OT_ObjExportAction(bpy.types.PropertyGroup):
     name: bpy.props.StringProperty(name="Action data name", default="Unknown", override={'LIBRARY_OVERRIDABLE'})
     use: bpy.props.BoolProperty(name="use this action", default=False, override={'LIBRARY_OVERRIDABLE'})
@@ -164,6 +186,8 @@ def get_object_prefix_name_to_export(obj: bpy.types.Object) -> str:
 classes = (
     BFU_UL_ActionExportTarget,
     BFU_OT_UpdateObjActionListButton,
+    BFU_OT_SelectAllObjActionListButton,
+    BFU_OT_DeselectAllObjActionListButton,
     BFU_OT_ObjExportAction,
 )
 

--- a/blender-for-unrealengine/bfu_anim_action/bfu_anim_action_ui.py
+++ b/blender-for-unrealengine/bfu_anim_action/bfu_anim_action_ui.py
@@ -64,9 +64,13 @@ def draw_ui(layout: bpy.types.UILayout, context: bpy.types.Context, obj: bpy.typ
                         maxrows=5,
                         rows=5
                     )
-                    ActionListProperty.operator(
+                    UpdateObjActionList = ActionListProperty.row()
+                    UpdateObjActionList.operator(
                         "object.updateobjactionlist",
                         icon='RECOVER_LAST')
+                    SelectDeselectObjActionList = ActionListProperty.row()
+                    SelectDeselectObjActionList.operator("object.selectallobjactionlist")
+                    SelectDeselectObjActionList.operator("object.deselectallobjactionlist")
                 if obj.bfu_anim_action_export_enum == "export_specific_prefix":
                     ActionListProperty.prop(obj, 'bfu_prefix_name_to_export')
 


### PR DESCRIPTION
<img width="227" height="241" alt="image" src="https://github.com/user-attachments/assets/a3644e24-0855-43ae-9883-81ba0d7b99e8" />

Since it was painful to click through the "export specific list" checkboxes when there were many actions, I added a "Select All" button and a "Deselect All" button.