### PR TITLE
Fix file type enum check

### DIFF
--- a/blender_for_unrealengine/bfu_custom_property/bfu_custom_property_ui.py
+++ b/blender_for_unrealengine/bfu_custom_property/bfu_custom_property_ui.py
@@ -17,7 +17,7 @@ def draw_ui_custom_property(layout: bpy.types.UILayout, obj: bpy.types.Object):
     else:
         export_type = bfu_static_mesh.bfu_export_procedure.get_obj_export_file_type(obj)
 
-    if export_type == "FBX":
+    if export_type.value == "FBX":
         layout.prop(obj, "bfu_fbx_export_with_custom_props")
         custom_props_layout = layout.column()
         custom_props_layout.enabled = obj.bfu_fbx_export_with_custom_props

--- a/blender_for_unrealengine/bfu_vertex_color/bfu_vertex_color_ui.py
+++ b/blender_for_unrealengine/bfu_vertex_color/bfu_vertex_color_ui.py
@@ -76,7 +76,7 @@ def draw_ui_object(layout: bpy.types.UILayout, context: bpy.types.Context, obj: 
             else:
                 export_type = bfu_static_mesh.bfu_export_procedure.get_obj_export_file_type(obj)
 
-            if export_type == "FBX":
+            if export_type.value == "FBX":
                 if blender_version >= (3, 4, 0):
                     bfu_vertex_color_settings.prop(obj, 'bfu_vertex_color_type')
                             


### PR DESCRIPTION
Fix `BFU_FileTypeEnum` enum check using literal value rather than its inner value. This fixes some of the UI elements not being shown in the menu.